### PR TITLE
fix: use more permissive argument passthrough for insert_all and upsert_all

### DIFF
--- a/acceptance/cases/models/insert_all_test.rb
+++ b/acceptance/cases/models/insert_all_test.rb
@@ -33,6 +33,12 @@ module ActiveRecord
         assert_raise(NotImplementedError) { Author.insert_all(values) }
       end
 
+      def test_insert
+        value = { id: Author.next_sequence_value, name: "Alice" }
+
+        assert_raise(NotImplementedError) { Author.insert(value) }
+      end
+
       def test_insert_all!
         values = [
           { id: Author.next_sequence_value, name: "Alice" },
@@ -83,6 +89,22 @@ module ActiveRecord
         assert_equal "Alice", authors[0].name
         assert_equal "Bob", authors[1].name
         assert_equal "Carol", authors[2].name
+      end
+
+      def test_upsert
+        Author.create id: 1, name: "David"
+        authors = Author.all.order(:name)
+        assert_equal 1, authors.length
+        assert_equal "David", authors[0].name
+
+        value = { id: 1, name: "Alice" }
+
+        Author.upsert(value)
+
+        authors = Author.all.order(:name)
+
+        assert_equal 1, authors.length
+        assert_equal "Alice", authors[0].name
       end
 
       def test_upsert_all

--- a/lib/activerecord_spanner_adapter/base.rb
+++ b/lib/activerecord_spanner_adapter/base.rb
@@ -67,11 +67,11 @@ module ActiveRecord
       _buffer_record values, :insert_or_update
     end
 
-    def self.insert_all _attributes, _returning: nil, _unique_by: nil
+    def self.insert_all _attributes, **_kwargs
       raise NotImplementedError, "Cloud Spanner does not support skip_duplicates."
     end
 
-    def self.insert_all! attributes, returning: nil
+    def self.insert_all! attributes, **kwargs
       return super unless spanner_adapter?
       return super if active_transaction? && !buffered_mutations?
 
@@ -90,7 +90,7 @@ module ActiveRecord
       end
     end
 
-    def self.upsert_all attributes, returning: nil, unique_by: nil
+    def self.upsert_all attributes, **kwargs
       return super unless spanner_adapter?
       if active_transaction? && !buffered_mutations?
         raise NotImplementedError, "Cloud Spanner does not support upsert using DML. " \


### PR DESCRIPTION
Full description is available here: https://github.com/googleapis/ruby-spanner-activerecord/pull/275