### PR TITLE
fix: permit use of super in _insert_record for Rails >= 7.0 and < 7.1

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -8,6 +8,7 @@ gem "minitest", "~> 5.20.0"
 gem "minitest-rg", "~> 5.3.0"
 gem "pry", "~> 0.13.0"
 gem "pry-byebug", "~> 3.9.0"
+gem "sqlite3"
 
 # Required for samples and testing.
 install_if -> { ENV.fetch("AR_VERSION", "~> 6.1.6.1").dup.to_s.sub!("~>", "").strip < "7.1.0" && !ENV["SKIP_COMPOSITE_PK"] } do

--- a/acceptance/cases/models/other_adapter_test.rb
+++ b/acceptance/cases/models/other_adapter_test.rb
@@ -1,0 +1,30 @@
+require "test_helper"
+require "models/project"
+
+module ActiveRecord
+  module Model
+    class OtherAdapterTest < SpannerAdapter::TestCase
+      attr_accessor :customer
+
+      def setup
+        super
+
+        ActiveRecord::Base.establish_connection sqlite_config
+        create_tables_in_sqlite_schema
+      end
+
+      def teardown
+        ActiveRecord::Base.establish_connection connector_config
+        super
+      end
+
+      def test_sqlite_customer_create
+        assert_equal 'sqlite', Project.connection.adapter_name.downcase
+        assert_nothing_raised do
+          Project.create plan_id: 1, system_id: 1
+        end
+        assert_equal 1, Project.count
+      end
+    end
+  end
+end

--- a/acceptance/models/project.rb
+++ b/acceptance/models/project.rb
@@ -1,0 +1,2 @@
+class Project < ActiveRecord::Base
+end

--- a/acceptance/schema/schema.rb
+++ b/acceptance/schema/schema.rb
@@ -194,3 +194,14 @@ def create_tables_in_test_schema
     end
   end
 end
+
+def create_tables_in_sqlite_schema
+  ActiveRecord::Schema.define(version: 1) do
+    # simulate a join table with no primary key
+    create_table :projects, id: false do |t|
+      t.integer  :plan_id
+      t.integer  :system_id
+      t.index [:plan_id, :system_id], unique: true
+    end
+  end
+end

--- a/acceptance/test_helper.rb
+++ b/acceptance/test_helper.rb
@@ -32,6 +32,13 @@ def connector_config
   }
 end
 
+def sqlite_config
+  {
+    "adapter" => "sqlite3",
+    "database" => ":memory:"
+  }
+end
+
 def spanner
   $spanner ||= Google::Cloud::Spanner.new(
     project_id: ENV["SPANNER_TEST_PROJECT"],


### PR DESCRIPTION
The 1.6.0 version of activerecord-spanner-adapter included a breaking change for Rails versions >= 7.0 and < 7.1 which arose when creating records on another database adapter for a table with no primary key.

It's already a little questionable that the Spanner adapter would be processing other adapter's queries, but breaking other adapters queries outright is a bit much.