### PR TITLE
Rebase `recurly` branch to match upstream.

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -8,6 +8,7 @@ gem "minitest", "~> 5.20.0"
 gem "minitest-rg", "~> 5.3.0"
 gem "pry", "~> 0.13.0"
 gem "pry-byebug", "~> 3.9.0"
+gem "sqlite3"
 
 # Required for samples and testing.
 install_if -> { ENV.fetch("AR_VERSION", "~> 6.1.6.1").dup.to_s.sub!("~>", "").strip < "7.1.0" && !ENV["SKIP_COMPOSITE_PK"] } do

--- a/acceptance/cases/models/other_adapter_test.rb
+++ b/acceptance/cases/models/other_adapter_test.rb
@@ -1,0 +1,30 @@
+require "test_helper"
+require "models/project"
+
+module ActiveRecord
+  module Model
+    class OtherAdapterTest < SpannerAdapter::TestCase
+      attr_accessor :customer
+
+      def setup
+        super
+
+        ActiveRecord::Base.establish_connection sqlite_config
+        create_tables_in_sqlite_schema
+      end
+
+      def teardown
+        ActiveRecord::Base.establish_connection connector_config
+        super
+      end
+
+      def test_sqlite_customer_create
+        assert_equal 'sqlite', Project.connection.adapter_name.downcase
+        assert_nothing_raised do
+          Project.create plan_id: 1, system_id: 1
+        end
+        assert_equal 1, Project.count
+      end
+    end
+  end
+end

--- a/acceptance/cases/type/time_test.rb
+++ b/acceptance/cases/type/time_test.rb
@@ -44,10 +44,28 @@ module ActiveRecord
         assert_equal expected_time, record.start_time
       end
 
-      def test_date_time_string_value_with_subsecond_precision
-        expected_time = ::Time.local 2017, 07, 4, 14, 19, 10, 897761
+      def test_date_time_string_value_with_timezone_aware_attributes
+        TestTypeModel.time_zone_aware_attributes = true
+        TestTypeModel.reset_column_information
 
         string_value = "2017-07-04 14:19:10.897761"
+        expected_time = ::Time.local 2017, 07, 4, 14, 19, 10, 897761
+
+        record = TestTypeModel.new start_time: string_value
+        assert_equal expected_time, record.start_time.utc
+
+        record.save!
+        assert_equal expected_time, record.start_time.utc
+
+        assert_equal record, TestTypeModel.find_by(start_time: string_value)
+      ensure
+        TestTypeModel.time_zone_aware_attributes = false
+        TestTypeModel.reset_column_information
+      end
+
+      def test_date_time_string_value_with_subsecond_precision
+        string_value = "2017-07-04 14:19:10.897761"
+        expected_time = ::Time.local 2017, 07, 4, 14, 19, 10, 897761
 
         record = TestTypeModel.new start_time: string_value
         assert_equal expected_time, record.start_time.utc
@@ -71,9 +89,21 @@ module ActiveRecord
         assert_equal record, TestTypeModel.find_by(start_time: string_value)
       end
 
-      def test_default_year_is_correct
+      def test_multiparameter_time
         expected_time = ::Time.utc(2000, 1, 1, 10, 30, 0)
         record = TestTypeModel.new start_time: { 4 => 10, 5 => 30 }
+
+        assert_equal expected_time, record.start_time
+
+        record.save!
+        record.reload
+
+        assert_equal expected_time, record.start_time
+      end
+
+      def test_multiparameter_datetime
+        expected_time = ::Time.utc(2020, 12, 25, 10, 30, 0)
+        record = TestTypeModel.new start_time: { 1 => 2020, 2 => 12, 3 => 25, 4 => 10, 5 => 30 }
 
         assert_equal expected_time, record.start_time
 

--- a/acceptance/models/project.rb
+++ b/acceptance/models/project.rb
@@ -1,0 +1,2 @@
+class Project < ActiveRecord::Base
+end

--- a/acceptance/schema/schema.rb
+++ b/acceptance/schema/schema.rb
@@ -194,3 +194,14 @@ def create_tables_in_test_schema
     end
   end
 end
+
+def create_tables_in_sqlite_schema
+  ActiveRecord::Schema.define(version: 1) do
+    # simulate a join table with no primary key
+    create_table :projects, id: false do |t|
+      t.integer  :plan_id
+      t.integer  :system_id
+      t.index [:plan_id, :system_id], unique: true
+    end
+  end
+end

--- a/acceptance/test_helper.rb
+++ b/acceptance/test_helper.rb
@@ -32,6 +32,13 @@ def connector_config
   }
 end
 
+def sqlite_config
+  {
+    "adapter" => "sqlite3",
+    "database" => ":memory:"
+  }
+end
+
 def spanner
   $spanner ||= Google::Cloud::Spanner.new(
     project_id: ENV["SPANNER_TEST_PROJECT"],

--- a/lib/active_record/connection_adapters/spanner/database_statements.rb
+++ b/lib/active_record/connection_adapters/spanner/database_statements.rb
@@ -213,10 +213,10 @@ module ActiveRecord
           sql_statement_type(sql) == :dml
         end
 
-        def execute_ddl statements
+        def execute_ddl statements, **options
           log "MIGRATION", "SCHEMA" do
             ActiveSupport::Dependencies.interlock.permit_concurrent_loads do
-              @connection.execute_ddl statements
+              @connection.execute_ddl statements, **options
             end
           end
         rescue Google::Cloud::Error => error

--- a/lib/active_record/connection_adapters/spanner/schema_creation.rb
+++ b/lib/active_record/connection_adapters/spanner/schema_creation.rb
@@ -53,7 +53,7 @@ module ActiveRecord
                          else
                            pk_names = o.columns.each_with_object [] do |c, r|
                              if c.type == :primary_key || c.primary_key?
-                               r << c.name
+                               r << (c.options[:primary_key].is_a?(Hash) ? c.options[:primary_key] : c.name)
                              end
                            end
                            PrimaryKeyDefinition.new pk_names
@@ -74,6 +74,18 @@ module ActiveRecord
           end
 
           create_sql
+        end
+
+        def visit_PrimaryKeyDefinition(o)
+          keys = o.name.map do |name|
+            if name.is_a?(Hash)
+              name.map { |col, sort| "#{quote_column_name(col)} #{sort.upcase}" }.join(', ')
+            else
+              quote_column_name(name)
+            end
+          end
+
+          "PRIMARY KEY (#{keys.join(', ')}"
         end
 
         def visit_DropTableDefinition o

--- a/lib/active_record/connection_adapters/spanner/schema_creation.rb
+++ b/lib/active_record/connection_adapters/spanner/schema_creation.rb
@@ -85,7 +85,7 @@ module ActiveRecord
             end
           end
 
-          "PRIMARY KEY (#{keys.join(', ')}"
+          "PRIMARY KEY (#{keys.join(', ')})"
         end
 
         def visit_DropTableDefinition o

--- a/lib/active_record/connection_adapters/spanner/schema_creation.rb
+++ b/lib/active_record/connection_adapters/spanner/schema_creation.rb
@@ -76,16 +76,16 @@ module ActiveRecord
           create_sql
         end
 
-        def visit_PrimaryKeyDefinition(o)
+        def visit_PrimaryKeyDefinition o
           keys = o.name.map do |name|
-            if name.is_a?(Hash)
-              name.map { |col, sort| "#{quote_column_name(col)} #{sort.upcase}" }.join(', ')
+            if name.is_a? Hash
+              name.map { |col, sort| "#{quote_column_name col} #{sort.upcase}" }.join(", ")
             else
-              quote_column_name(name)
+              quote_column_name name
             end
           end
 
-          "PRIMARY KEY (#{keys.join(', ')})"
+          "PRIMARY KEY (#{keys.join ', '})"
         end
 
         def visit_DropTableDefinition o

--- a/lib/active_record/connection_adapters/spanner/schema_statements.rb
+++ b/lib/active_record/connection_adapters/spanner/schema_statements.rb
@@ -277,6 +277,8 @@ module ActiveRecord
           end
         else
           def remove_index table_name, column_name = nil, **options
+            return if options[:if_exists] && !index_exists?(table_name, column_name, **options)
+
             index_name = index_name_for_remove table_name, column_name, options
             execute "DROP INDEX #{quote_table_name index_name}"
           end

--- a/lib/active_record/connection_adapters/spanner/schema_statements.rb
+++ b/lib/active_record/connection_adapters/spanner/schema_statements.rb
@@ -258,7 +258,7 @@ module ActiveRecord
           information_schema { |i| i.index table_name, index_name }.present?
         end
 
-        def add_index table_name, column_name, options = {}
+        def add_index table_name, column_name, wait_until_done: true, **options
           id = create_index_definition table_name, column_name, **options
 
           if data_source_exists?(table_name) &&
@@ -267,7 +267,7 @@ module ActiveRecord
                                  "'#{table_name}' already exists"
           end
 
-          execute_schema_statements schema_creation.accept(id)
+          execute_schema_statements schema_creation.accept(id), wait_until_done: wait_until_done
         end
 
         if ActiveRecord.gem_version < VERSION_6_1_0
@@ -617,8 +617,8 @@ module ActiveRecord
           statements
         end
 
-        def execute_schema_statements statements
-          execute_ddl statements
+        def execute_schema_statements statements, **options
+          execute_ddl statements, **options
         end
 
         def information_schema

--- a/lib/active_record/type/spanner/time.rb
+++ b/lib/active_record/type/spanner/time.rb
@@ -25,7 +25,7 @@ module ActiveRecord
         end
 
         def user_input_in_time_zone value
-          return value.in_time_zone if value.is_a? ::Time
+          return value.in_time_zone if value.respond_to?(:in_time_zone)
           super value
         end
 

--- a/lib/active_record/type/spanner/time.rb
+++ b/lib/active_record/type/spanner/time.rb
@@ -25,7 +25,7 @@ module ActiveRecord
         end
 
         def user_input_in_time_zone value
-          return value.in_time_zone if value.respond_to?(:in_time_zone)
+          return value.in_time_zone if value.respond_to? :in_time_zone
           super value
         end
 


### PR DESCRIPTION
1.6.0 -> 1.6.2, includes better support for multi-database projects, including the `_insert_all` bug we nudged them on. 